### PR TITLE
Move Proxy Configuration into Session; Reformatting

### DIFF
--- a/zenodolib.py
+++ b/zenodolib.py
@@ -60,8 +60,8 @@ class ZenodoHandler:
             self.base_url = "https://zenodo.org/api/"
 
         self.token = access_token
-        self.proxies = proxies
         self.session = requests.Session()
+        self.session.proxies.update(proxies)
         self.session.params['access_token'] = access_token
 
     def deposition_list(self):
@@ -73,7 +73,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions".format(
             self.base_url)
-        return self.session.get(url, proxies=self.proxies)
+        return self.session.get(url)
 
     def deposition_create(self):
         """
@@ -87,8 +87,7 @@ class ZenodoHandler:
         url = "{}deposit/depositions".format(
             self.base_url)
         headers = {"Content-Type": "application/json"}
-        return self.session.post(url, data="{}", headers=headers,
-                                 proxies=self.proxies)
+        return self.session.post(url, data="{}", headers=headers)
 
     def deposition_retrieve(self, deposition_id):
         """
@@ -101,7 +100,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}".format(
             self.base_url, deposition_id)
-        return self.session.get(url, proxies=self.proxies)
+        return self.session.get(url)
 
     def deposition_update(self, deposition_id, data):
         """
@@ -116,8 +115,7 @@ class ZenodoHandler:
         url = "{}deposit/depositions/{}".format(
             self.base_url, deposition_id)
         headers = {"Content-Type": "application/json"}
-        return self.session.put(url, data=json.dumps(data), headers=headers,
-                                proxies=self.proxies)
+        return self.session.put(url, data=json.dumps(data), headers=headers)
 
     def deposition_delete(self, deposition_id):
         """
@@ -130,7 +128,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}".format(
             self.base_url, deposition_id)
-        return self.session.delete(url, proxies=self.proxies)
+        return self.session.delete(url)
 
     def deposition_files_list(self, deposition_id):
         """
@@ -143,7 +141,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}/files".format(
             self.base_url, deposition_id)
-        return self.session.get(url, proxies=self.proxies)
+        return self.session.get(url)
 
     def deposition_files_create(self, deposition_id, target_name, file_path):
         """
@@ -161,8 +159,7 @@ class ZenodoHandler:
         url = "{}/{}".format(bucket_url, target_name)
         data = {'file': open(file_path, 'rb')}
         headers = {"Accept": "application/json", "Content-Type": "application/octet-stream"}
-        return self.session.put(url, data=data, headers=headers,
-                                proxies=self.proxies)
+        return self.session.put(url, data=data, headers=headers)
 
     def deposition_files_sort(self, deposition_id, file_ids):
         """
@@ -178,8 +175,7 @@ class ZenodoHandler:
             self.base_url, deposition_id)
         headers = {"Content-Type": "application/json"}
         data = json.dumps({'id': file_id for file_id in file_ids})
-        return self.session.put(url, data=data, headers=headers,
-                                proxies=self.proxies)
+        return self.session.put(url, data=data, headers=headers)
 
     def deposition_files_retrieve(self, deposition_id, file_id):
         """
@@ -193,7 +189,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}/files/{}".format(
             self.base_url, deposition_id, file_id)
-        return self.session.get(url, proxies=self.proxies)
+        return self.session.get(url)
 
     def deposition_files_update(self, deposition_id, file_id, target_name):
         """
@@ -213,8 +209,7 @@ class ZenodoHandler:
         headers = {"Content-Type": "application/json"}
         data = json.dumps({"filename", target_name})
 
-        return self.session.put(url, data=data, headers=headers,
-                            proxies=self.proxies)
+        return self.session.put(url, data=data, headers=headers)
 
     def deposition_files_delete(self, deposition_id, file_id):
         """
@@ -229,7 +224,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}/files/{}".format(
             self.base_url, deposition_id, file_id)
-        return self.session.delete(url, proxies=self.proxies)
+        return self.session.delete(url)
 
     def deposition_actions_publish(self, deposition_id):
         """
@@ -243,7 +238,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}/actions/publish".format(
             self.base_url, deposition_id)
-        return self.session.post(url, proxies=self.proxies)
+        return self.session.post(url)
 
     def deposition_actions_edit(self, deposition_id):
         """
@@ -256,7 +251,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}/actions/edit".format(
             self.base_url, deposition_id)
-        return self.session.post(url, proxies=self.proxies)
+        return self.session.post(url)
 
     def deposition_actions_discard(self, deposition_id):
         """
@@ -269,7 +264,7 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}/actions/discard".format(
             self.base_url, deposition_id)
-        return self.session.post(url, proxies=self.proxies)
+        return self.session.post(url)
 
     def deposition_actions_newversion(self, deposition_id):
         """
@@ -282,4 +277,4 @@ class ZenodoHandler:
         """
         url = "{}deposit/depositions/{}/actions/newversion".format(
             self.base_url, deposition_id)
-        return self.session.post(url, proxies=self.proxies)
+        return self.session.post(url)

--- a/zenodolib.py
+++ b/zenodolib.py
@@ -71,8 +71,7 @@ class ZenodoHandler:
         - Url: https://zenodo.org/api/deposit/depositions
         - Method: GET
         """
-        url = "{}deposit/depositions".format(
-            self.base_url)
+        url = "{}deposit/depositions".format(self.base_url)
         return self.session.get(url)
 
     def deposition_create(self):
@@ -84,8 +83,7 @@ class ZenodoHandler:
 
         : param deposition_id: Deposition identifier
         """
-        url = "{}deposit/depositions".format(
-            self.base_url)
+        url = "{}deposit/depositions".format(self.base_url)
         headers = {"Content-Type": "application/json"}
         return self.session.post(url, data="{}", headers=headers)
 
@@ -98,8 +96,7 @@ class ZenodoHandler:
 
         :param deposition_id: Deposition identifier
         """
-        url = "{}deposit/depositions/{}".format(
-            self.base_url, deposition_id)
+        url = "{}deposit/depositions/{}".format(self.base_url, deposition_id)
         return self.session.get(url)
 
     def deposition_update(self, deposition_id, data):
@@ -112,8 +109,7 @@ class ZenodoHandler:
         :param deposition_id: Deposition identifier
         :param data: Data to upload
         """
-        url = "{}deposit/depositions/{}".format(
-            self.base_url, deposition_id)
+        url = "{}deposit/depositions/{}".format(self.base_url, deposition_id)
         headers = {"Content-Type": "application/json"}
         return self.session.put(url, data=json.dumps(data), headers=headers)
 
@@ -126,8 +122,7 @@ class ZenodoHandler:
 
         :param deposition_id: Deposition identifier
         """
-        url = "{}deposit/depositions/{}".format(
-            self.base_url, deposition_id)
+        url = "{}deposit/depositions/{}".format(self.base_url, deposition_id)
         return self.session.delete(url)
 
     def deposition_files_list(self, deposition_id):
@@ -158,7 +153,8 @@ class ZenodoHandler:
         bucket_url = r.json()['links']['bucket']
         url = "{}/{}".format(bucket_url, target_name)
         data = {'file': open(file_path, 'rb')}
-        headers = {"Accept": "application/json", "Content-Type": "application/octet-stream"}
+        headers = {"Accept": "application/json",
+                   "Content-Type": "application/octet-stream"}
         return self.session.put(url, data=data, headers=headers)
 
     def deposition_files_sort(self, deposition_id, file_ids):
@@ -193,8 +189,9 @@ class ZenodoHandler:
 
     def deposition_files_update(self, deposition_id, file_id, target_name):
         """
-        Update a deposition file resource. Currently the only use is renaming an
-        already uploaded file. If you want to to replace the actual file, please
+        Update a deposition file resource.
+        Currently the only use is renaming an already uploaded file.
+        If you want to to replace the actual file, please
         delete the file and upload new file.
 
         - Url: https://zenodo.org/api/deposit/depositions/:id/files/:file_id
@@ -213,8 +210,8 @@ class ZenodoHandler:
 
     def deposition_files_delete(self, deposition_id, file_id):
         """
-        Delete an existing deposition file resource. Note, only deposition files
-        for unpublished depositions may be deleted.
+        Delete an existing deposition file resource.
+        Note, only deposition files for unpublished depositions may be deleted.
 
         - Url: https://zenodo.org/api/deposit/depositions/:id/files/:file_id
         - Method: DELETE

--- a/zenodolib.py
+++ b/zenodolib.py
@@ -68,7 +68,7 @@ class ZenodoHandler:
         """
         List all depositions for the currently authenticated user.
 
-        - Url: https://zenodo.org/api/deposit/depositions
+        - Path: /api/deposit/depositions
         - Method: GET
         """
         url = "{}deposit/depositions".format(self.base_url)
@@ -78,7 +78,7 @@ class ZenodoHandler:
         """
         Create a new deposition resource.
 
-        - Url: https://zenodo.org/api/deposit/depositions
+        - Path: /api/deposit/depositions
         - Method: POST
 
         : param deposition_id: Deposition identifier
@@ -91,7 +91,7 @@ class ZenodoHandler:
         """
         Retrieve a single deposition resource.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id
+        - Path: /api/deposit/depositions/:id
         - Method: GET
 
         :param deposition_id: Deposition identifier
@@ -103,7 +103,7 @@ class ZenodoHandler:
         """
         Update an existing deposition resource.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id
+        - Path: /api/deposit/depositions/:id
         - Method: PUT
 
         :param deposition_id: Deposition identifier
@@ -117,7 +117,7 @@ class ZenodoHandler:
         """
         Delete an existing deposition resource.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id
+        - Path: /api/deposit/depositions/:id
         - Method: DELETE
 
         :param deposition_id: Deposition identifier
@@ -129,7 +129,7 @@ class ZenodoHandler:
         """
         List all deposition files for a given deposition.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/files
+        - Path: /api/deposit/depositions/:id/files
         - Method: GET
 
         :param deposition_id: Deposition identifier
@@ -142,7 +142,7 @@ class ZenodoHandler:
         """
         Upload a new file.
 
-        - Url: https://zenodo.org/api/files/:bucket_url/:target_name
+        - Path: /api/files/:bucket_url/:target_name
         - Methods: PUT
 
         :param deposition_id: Deposition identifier
@@ -161,7 +161,7 @@ class ZenodoHandler:
         """
         Sort the files for a deposition. By default, the first file is show
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/files
+        - Path: /api/deposit/depositions/:id/files
         - Method: PUT
 
         :param deposition_id: Deposition identifier
@@ -177,7 +177,7 @@ class ZenodoHandler:
         """
         Retrieve a single deposition file.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/files/:file_id
+        - Path: /api/deposit/depositions/:id/files/:file_id
         - Method: GET
 
         :param deposition_id: Deposition identifier
@@ -194,7 +194,7 @@ class ZenodoHandler:
         If you want to to replace the actual file, please
         delete the file and upload new file.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/files/:file_id
+        - Path: /api/deposit/depositions/:id/files/:file_id
         - Method: PUT
 
         :param deposition_id: Deposition identifier
@@ -213,7 +213,7 @@ class ZenodoHandler:
         Delete an existing deposition file resource.
         Note, only deposition files for unpublished depositions may be deleted.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/files/:file_id
+        - Path: /api/deposit/depositions/:id/files/:file_id
         - Method: DELETE
 
         :param deposition_id: Deposition identifier
@@ -228,7 +228,7 @@ class ZenodoHandler:
         Publish a deposition. Note, once a deposition is published, you can
         no longer delete it.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/actions/publish
+        - Path: /api/deposit/depositions/:id/actions/publish
         - Method: POST
 
         :param deposition_id: Deposition identifier.
@@ -241,7 +241,7 @@ class ZenodoHandler:
         """
         Unlock already submitted deposition for editing.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/actions/edit
+        - Path: /api/deposit/depositions/:id/actions/edit
         - Method: POST
 
         :param deposition_id: Deposition identifier.
@@ -254,7 +254,7 @@ class ZenodoHandler:
         """
         Discard changes in the current editing session.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/actions/discard
+        - Path: /api/deposit/depositions/:id/actions/discard
         - Method: POST
 
         :param deposition_id: Deposition identifier
@@ -267,7 +267,7 @@ class ZenodoHandler:
         """
         Creates a new version of an existing deposition resource.
 
-        - Url: https://zenodo.org/api/deposit/depositions/:id/actions/newversion
+        - Path: /api/deposit/depositions/:id/actions/newversion
         - Method: POST
 
         :param deposition_id: Deposition identifier


### PR DESCRIPTION
The proxy configuration can be set on the Session as well. So move the proxy setting from each request to the Session object.

Also some reformatting:
* line breaking and joining
* Shorten the URLs in the doc strings to only contain the path, because the host is different for `test=True`
* This makes everything flake8 clean now